### PR TITLE
Use dist-upgrade rather than upgrade

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,7 +11,7 @@ execute "apt-update" do
 end
 
 execute "apt-upgrade" do
-  command 'DEBIAN_FRONTEND=noninteractive apt-get -fuy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade'
+  command 'DEBIAN_FRONTEND=noninteractive apt-get -fuy -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade'
   action :nothing
 end
 


### PR DESCRIPTION
The upgrade approach leaves a bunch of packages non-upgraded on a fresh Ubuntu 16.04 install:

```
plundberg@some-server:~$ sudo apt-get upgrade
Reading package lists... Done
Building dependency tree
Reading state information... Done
Calculating upgrade... Done
The following packages have been kept back:
  linux-generic linux-headers-generic linux-image-generic open-vm-tools
0 upgraded, 0 newly installed, 0 to remove and 4 not upgraded.
```

I think doing a dist-upgrade makes more sense, and it should be safe to run on a freshly installed machine anyway. What do you think?